### PR TITLE
Delete too mach log lines and add getBuilder() replace new Builder()

### DIFF
--- a/alog/src/main/java/com/blankj/ALog.java
+++ b/alog/src/main/java/com/blankj/ALog.java
@@ -130,6 +130,10 @@ public final class ALog {
         }
     }
 
+    public static Builder getBuilder(Context context){
+        return new Builder(context);
+    }
+
     public static void v(Object contents) {
         log(V, sGlobalTag, contents);
     }
@@ -284,10 +288,12 @@ public final class ALog {
         String msg = head + body;
         if (sLogBorderSwitch) {
             StringBuilder sb = new StringBuilder();
+            sb.append(TOP_BORDER).append(LINE_SEPARATOR);
             String[] lines = msg.split(LINE_SEPARATOR);
             for (String line : lines) {
                 sb.append(LEFT_BORDER).append(line).append(LINE_SEPARATOR);
             }
+            sb.append(BOTTOM_BORDER).append(LINE_SEPARATOR);
             msg = sb.toString();
         }
         return new String[]{tag, msg};
@@ -322,7 +328,6 @@ public final class ALog {
     }
 
     private static void printLog(int type, String tag, String msg) {
-        if (sLogBorderSwitch) print(type, tag, TOP_BORDER);
         int len = msg.length();
         int countOfSub = len / MAX_LEN;
         if (countOfSub > 0) {
@@ -339,7 +344,6 @@ public final class ALog {
         } else {
             print(type, tag, msg);
         }
-        if (sLogBorderSwitch) print(type, tag, BOTTOM_BORDER);
     }
 
     private static void print(final int type, final String tag, String msg) {


### PR DESCRIPTION

在打印一行时,产生了三次输出,这样前面会有三个TAG信息.其实只要保留一个就行了

![newstate](https://cloud.githubusercontent.com/assets/9072872/25415122/4da94f2a-2a68-11e7-9041-218e50fccc41.png)

### 建议

另外建议将Builder改名为Settings. 

我的本地版本是这样使用的, 这样就没有必要浪application持有这个对象,且无论在哪使用都直接用,毕竟实质上它只是为了改变Log类里面的静态变量提供一个入口而已.

``` java
    /**
     * the setting enter <br>
     * <code>
     * ALog.getSettings()
     *         .setLogLevel(Log.WARN)
     *         .setBorderEnable(true)
     *         .setLogEnable(true);
     * </code>
     * @return
     */
    public static Settings getSettings() {
        return new Settings();
    }
```
